### PR TITLE
Call pip with the subprocess module.

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,15 +1,5 @@
+import subprocess
 import sys
-
-# https://stackoverflow.com/a/51704613
-try:
-    from pip import main as pipmain
-except ImportError:
-    from pip._internal import main as pipmain
-
-# More pip changes breaking us.
-main_fn = pipmain
-if hasattr(pipmain, 'main'):
-    main_fn = pipmain.main
 
 DEFAULT_LOGGER = 'rlbot'
 
@@ -23,7 +13,7 @@ if __name__ == '__main__':
             logger.log(logging_utils.logging_level,
                        'Skipping upgrade check for now since it looks like you have no internet')
         elif public_utils.is_safe_to_upgrade():
-            main_fn(['install', '-r', 'requirements.txt', '--upgrade', '--upgrade-strategy=eager'])
+            subprocess.call([sys.executable, "-m", "pip", "install", '-r', 'requirements.txt', '--upgrade', '--upgrade-strategy=eager'])
 
             # https://stackoverflow.com/a/44401013
             rlbots = [module for module in sys.modules if module.startswith('rlbot')]
@@ -31,7 +21,7 @@ if __name__ == '__main__':
                 sys.modules.pop(rlbot_module)
 
     except ImportError:
-        main_fn(['install', '-r', 'requirements.txt', '--upgrade', '--upgrade-strategy=eager'])
+        subprocess.call([sys.executable, "-m", "pip", "install", '-r', 'requirements.txt', '--upgrade', '--upgrade-strategy=eager'])
 
     try:
         if len(sys.argv) > 1 and sys.argv[1] == 'gui':


### PR DESCRIPTION
Pip is not supposed to be imported. The recommended method is to call pip as a subprocess, see https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program

I have decided to use `subprocess.call` over `subprocess.check_call` because the latter throws an exception when a package fails to install. The rlbottraining package fails to install if the python version is below 3.7 but is not required to succesfully run rlbot.