### PR TITLE
64 is the new 10

### DIFF
--- a/rlbot.cfg
+++ b/rlbot.cfg
@@ -5,7 +5,7 @@
 # Visit https://github.com/RLBot/RLBot/wiki/Config-File-Documentation to see what you can put here.
 
 [Match Configuration]
-# Number of bots/players which will be spawned.  We support up to max 10.
+# Number of bots/players which will be spawned.  We support up to max 64.
 num_participants = 2
 game_mode = Soccer
 game_map = Mannfield


### PR DESCRIPTION
> An outdated comment is worse than no comment at all. This turns the comment into a lie, and we don't want lies in our code. - David Scott Bernstein