### PR TITLE
Switching to the autocomplete version of GameTickPacket.

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -1,7 +1,7 @@
 import math
 
 from rlbot.agents.base_agent import BaseAgent, SimpleControllerState
-from rlbot.utils.structures.game_data_struct import GameTickPacket
+from rlbot.utils.structures.game_data_struct_autocomplete import GameTickPacket
 
 from util.orientation import Orientation
 from util.vec import Vec3


### PR DESCRIPTION
This takes advantage of https://github.com/RLBot/RLBot/pull/467, which has now been deployed to pypi as version 1.35.1. Bot makers will get code completion support from more IDEs so they don't need to reference https://github.com/RLBot/RLBotPythonExample/wiki/Input-and-Output-Data#sample-game-tick-packet as heavily.