### PR TITLE
Example unit test should load the example bot

### DIFF
--- a/training/hello_world_training.py
+++ b/training/hello_world_training.py
@@ -26,6 +26,17 @@ def make_match_config_with_my_bot() -> MatchConfig:
     ]
     return match_config
 
+
+def add_my_bot_to_playlist(exercises: Playlist) -> Playlist:
+    """
+    Updates the match config for each excercise to include
+    the bot from this project
+    """
+    for exercise in exercises:
+        exercise.match_config = make_match_config_with_my_bot()
+    return exercises
+
+
 @dataclass
 class StrikerPatience(StrikerExercise):
     """
@@ -90,7 +101,4 @@ def make_default_playlist() -> Playlist:
         DrivesToBallExercise('Get close to ball'),
         DrivesToBallExercise('Get close-ish to ball', grader=DriveToBallGrader(min_dist_to_pass=1000))
     ]
-    for exercise in exercises:
-        exercise.match_config = make_match_config_with_my_bot()
-
-    return exercises
+    return add_my_bot_to_playlist(exercises)

--- a/training/unit_tests.py
+++ b/training/unit_tests.py
@@ -3,7 +3,7 @@ import unittest
 from rlbot.training.training import Pass, Fail
 from rlbottraining.exercise_runner import run_playlist
 
-from hello_world_training import StrikerPatience
+from hello_world_training import StrikerPatience, add_my_bot_to_playlist
 
 class PatienceTest(unittest.TestCase):
     """
@@ -18,7 +18,8 @@ class PatienceTest(unittest.TestCase):
     """
 
     def test_patience_required(self):
-        result_iter = run_playlist([StrikerPatience(name='patience required')])
+        playlist = [StrikerPatience(name='patience required')]
+        result_iter = run_playlist(add_my_bot_to_playlist(playlist))
         results = list(result_iter)
         self.assertEqual(len(results), 1)
         result = results[0]
@@ -26,7 +27,8 @@ class PatienceTest(unittest.TestCase):
         self.assertIsInstance(result.grade, Fail)  # If you make the bot is smarter, update this assert that we pass.
 
     def test_no_patience_required(self):
-        result_iter = run_playlist([StrikerPatience(name='no patience required', car_start_x=-1000)])
+        playlist = [StrikerPatience(name='no patience required', car_start_x=-1000)]
+        result_iter = run_playlist(add_my_bot_to_playlist(playlist))
         results = list(result_iter)
         self.assertEqual(len(results), 1)
         result = results[0]


### PR DESCRIPTION
A match config was not being set on the excercise, resulting
in Simple Bot being initialized instead of the bot
in the project.